### PR TITLE
Gamma Correction

### DIFF
--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -56,6 +56,7 @@ ColorsUsed(0)
         Color->CaptureSource = ESceneCaptureSource::SCS_FinalColorLDR;
         Color->TextureTarget = CreateDefaultSubobject<UTextureRenderTarget2D>(TEXT("ColorTarget"));
         Color->TextureTarget->InitAutoFormat(Width, Height);
+		Color->TextureTarget->TargetGamma = 2.3f;
         Color->FOVAngle = FieldOfView;
 
         Depth = CreateDefaultSubobject<USceneCaptureComponent2D>(TEXT("DepthCapture"));

--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -56,7 +56,7 @@ ColorsUsed(0)
         Color->CaptureSource = ESceneCaptureSource::SCS_FinalColorLDR;
         Color->TextureTarget = CreateDefaultSubobject<UTextureRenderTarget2D>(TEXT("ColorTarget"));
         Color->TextureTarget->InitAutoFormat(Width, Height);
-		Color->TextureTarget->TargetGamma = 2.3f;
+	Color->TextureTarget->TargetGamma = 2.3f;
         Color->FOVAngle = FieldOfView;
 
         Depth = CreateDefaultSubobject<USceneCaptureComponent2D>(TEXT("DepthCapture"));


### PR DESCRIPTION
Corrects the brightness using the target gamma parameter of the TextureTarget inside the ColorCapture for the vision component.
![gammaCorrection](https://user-images.githubusercontent.com/47766561/79726678-23275e80-8326-11ea-8604-5c9a97add959.png)

Signed-off-by: Sj-Amani <s-amani@seaos.co.jp>