### PR TITLE
UE4.25 Support

### DIFF
--- a/Source/ROSIntegrationVision/Private/VisionComponent.cpp
+++ b/Source/ROSIntegrationVision/Private/VisionComponent.cpp
@@ -512,7 +512,6 @@ void UVisionComponent::ReadImageCompressed(UTextureRenderTarget2D *RenderTarget,
 	static IImageWrapperModule& ImageWrapperModule = FModuleManager::LoadModuleChecked<IImageWrapperModule>(FName("ImageWrapper"));
 	static TSharedPtr<IImageWrapper> ImageWrapper = ImageWrapperModule.CreateImageWrapper(EImageFormat::PNG);
 	ImageWrapper->SetRaw(RawImageData.GetData(), RawImageData.GetAllocatedSize(), Width, Height, ERGBFormat::BGRA, 8);
-	const TArray<uint8>& ImgData = ImageWrapper->GetCompressed();
 }
 
 void UVisionComponent::ToColorImage(const TArray<FFloat16Color> &ImageData, uint8 *Bytes) const

--- a/Source/ROSIntegrationVision/Public/ROSIntegrationVision.h
+++ b/Source/ROSIntegrationVision/Public/ROSIntegrationVision.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "ModuleManager.h"
+#include "Modules/ModuleManager.h"
 
 class FROSIntegrationVisionModule : public IModuleInterface
 {
@@ -24,7 +24,7 @@ public:
 		return FModuleManager::LoadModuleChecked< FROSIntegrationVisionModule >("ROSIntegrationVision");
 	}
 
-	/** 
+	/**
 	* Checks to see if this module is loaded and ready.  It is only valid to call Get() if IsAvailable() returns true.
 	*
 	* @return True if the module is loaded and ready to use


### PR DESCRIPTION
#### Summary

Closes #3 

The ImageWrapper->GetCompressed line called inside UVisionComponent::ReadImageCompressed is not utilized elsewhere, thus it was simply removed.